### PR TITLE
fixes bug when using new ..()

### DIFF
--- a/lib/scanner.js
+++ b/lib/scanner.js
@@ -94,7 +94,7 @@ var NodeTypes = {
 	},
 
 	NewExpression: function (node) {
-		return node.argument;
+		return node.arguments;
 	},
 
 	ObjectExpression: function (node) {


### PR DESCRIPTION
Thank you for implementing a grunt-agnostic version of neuter. I was having some trouble if the "neutered" files contain a new statement.

For example:

```
var test = new String('test');
```

The error message:

```
PATH_DELETED\node_modules\gulp-neuter\node_modules\neuter\lib\scanner.js:220
                                if (childNode.type === 'FunctionDeclaration' ||
                                             ^
TypeError: Cannot read property 'type' of undefined
    at Immediate._onImmediate (PATH_DELETED\node_modules\gulp-neuter\node_modules\neuter\lib\scanner.js:220:18)
    at processImmediate [as _immediateCallback] (timers.js:374:17)
```

I'm using node v0.11.12.
