### PR TITLE
bugfix: errors during (esprima) parsing of source files are forwarded correctly via callbacks

### DIFF
--- a/lib/neuter.js
+++ b/lib/neuter.js
@@ -201,6 +201,11 @@ Neuter.prototype.loadSource = function(file, done) {
 		scanner(file.contents.toString(), 'require', (function(err, calls) {
 			var contents = file.contents.toString();
 
+			if (err) {
+				var error = new Error('Error parsing ' + file.path + ' - ' + err);
+				return done(error);
+			}
+
 			if (calls.length == 0) {
 				done(null, [{
 					file: file.path,

--- a/lib/scanner.js
+++ b/lib/scanner.js
@@ -188,9 +188,17 @@ var NodeTypes = {
 };
 
 module.exports = function(source, functionName, done) {
-	var program = esprima.parse(source, {
-		range: true,
-	});
+
+	var program;
+
+	try {
+		program = esprima.parse(source, {
+			range:true
+		});
+	}
+	catch(err) {
+		return done(err);
+	}
 
 	function scanNode(node, done) {
 		setImmediate(function () {

--- a/test/file_interface_test.js
+++ b/test/file_interface_test.js
@@ -613,5 +613,20 @@ describe('When passing a file as input source', function() {
 				});
 			});
 		});
+
+		it('with syntax errors should forward exceptions to callback', function(done) {
+			readFileAsync('test/fixtures/syntax_error.js', function(err, sourceFile) {
+				if (err) {
+					throw err;
+				}
+
+				new Neuter({}).parse(sourceFile, function(err, result) {
+					should(err).be.an.Error;
+					should(err.message).match(new RegExp('test' + path.sep + 'fixtures' + path.sep + 'syntax_error.js', 'i'));
+					should(err.message).match(new RegExp('unexpected identifier', 'i'));
+					done();
+				});
+			})
+		})
 	});
 });

--- a/test/fixtures/syntax_error.js
+++ b/test/fixtures/syntax_error.js
@@ -1,0 +1,1 @@
+invalid code;

--- a/test/neuter_test.js
+++ b/test/neuter_test.js
@@ -494,5 +494,15 @@ describe('When passing a filepath as input source', function() {
 				});
 			});
 		});
+
+		it('with syntax errors should forward exceptions to callback', function(done) {
+
+			new Neuter({}).parse('test/fixtures/syntax_error.js', function(err, result) {
+				should(err).be.an.Error;
+				should(err.message).match(new RegExp('test' + path.sep + 'fixtures' + path.sep + 'syntax_error.js', 'i'));
+				should(err.message).match(new RegExp('unexpected identifier', 'i'));
+				done();
+			});
+		});
 	});
 });


### PR DESCRIPTION
This fix will catch parser exceptions by esprima and forward them via callback. The messages are enriched with the actual filename.
