### PR TITLE
Added check for constructor nodes

### DIFF
--- a/lib/scanner.js
+++ b/lib/scanner.js
@@ -223,6 +223,10 @@ module.exports = function(source, functionName, done) {
 			for (var i = 0; i < childNodes.length; i++) {
 				var childNode = childNodes[i];
 
+				if (!childNode) {
+					continue;
+				}
+				
 				if (childNode.type === 'FunctionDeclaration' ||
 					childNode.type === 'VariableDeclarator') {
 					if (childNode.id.name === functionName) {


### PR DESCRIPTION
On constructor nodes the following error would trigger;

```
/Users/Jorick/Sites/animo-web-2.0/node_modules/gulp-neuter/node_modules/neuter/lib/scanner.js:213
                if (childNode.type === 'FunctionDeclaration' ||
                             ^
TypeError: Cannot read property 'type' of undefined
    at Immediate._onImmediate (/Users/Jorick/Sites/animo-web-2.0/node_modules/gulp-neuter/node_modules/neuter/lib/scanner.js:213:18)
    at processImmediate [as _immediateCallback] (timers.js:358:17)
```

This commit fixes this problem.
